### PR TITLE
scripts/xrfi_simple.py: fix crash with newer versions of Numpy

### DIFF
--- a/scripts/xrfi_simple.py
+++ b/scripts/xrfi_simple.py
@@ -80,20 +80,20 @@ for uvfile in args:
                 ddf2 = n.abs(ddf)**2
                 sig = n.sqrt(n.median(ddf2, axis=1))
                 sig.shape = (sig.size,1)
-                m[:,0] |= 1; m[:,-1] |= 1
-                m[:,1:-1] |= n.where(ddf2/sig**2 > opts.df**2, 1, 0)
+                m[:,0] |= True; m[:,-1] |= True
+                m[:,1:-1] |= n.where(ddf2/sig**2 > opts.df**2, True, False)
             if opts.dt != None:
                 ddt = d[1:-1,:] - .5 * (d[:-2,:] + d[2:,:])
                 ddt2 = n.abs(ddt)**2
                 sig = n.sqrt(n.median(ddt2, axis=0))
                 sig.shape = (1,sig.size)
-                m[0,:] |= 1; m[-1,:] |= 1
-                m[1:-1,:] |= n.where(ddt2/sig**2 > opts.dt**2, 1, 0)
+                m[0,:] |= True; m[-1,:] |= True
+                m[1:-1,:] |= n.where(ddt2/sig**2 > opts.dt**2, True, False)
             if opts.df == None and opts.dt == None:
                 ad = n.abs(d)
                 med = n.median(ad)
                 sig = n.sqrt(n.median(n.abs(ad-med)**2))
-                m |= n.where(ad > med + opts.nsig * sig, 1, 0)
+                m |= n.where(ad > med + opts.nsig * sig, True, False)
             for i, t in enumerate(data_times): mask[pol][bl][t] |= m[i]
         if opts.combine:
             new_mask = {}


### PR DESCRIPTION
What the commit message says:

Numpy is now stricter about casting, and was crashing with complaints about implicit casts between
bools and ints.
