### PR TITLE
Ubuntu(16.-04 security error Fix

### DIFF
--- a/src/_healpix/alm_wrap.cpp
+++ b/src/_healpix/alm_wrap.cpp
@@ -67,7 +67,7 @@ void option_err(char *options[]) {
         i++;
     }
     strcat(errstr, "]");
-    PyErr_Format(PyExc_ValueError, errstr);
+    PyErr_Format(PyExc_ValueError, "%s", errstr);
 }
     
 int get_option(char *options[], PyObject *choice) {
@@ -124,7 +124,7 @@ static int AlmObject_init(AlmObject *self, PyObject *args, PyObject *kwds) {
         self->alm = Alm<xcomplex<double> >(lmax, mmax);
         self->alm.SetToZero();
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return -1;
     }
     return 0;
@@ -143,14 +143,14 @@ static PyObject * AlmObject_get(AlmObject *self, PyObject *args) {
     xcomplex<double> c;
     if (!PyArg_ParseTuple(args, "ii", &l, &m)) return NULL;
     if (l < 0 || l > lmax || m < 0 || m > mmax || m > l) {
-        PyErr_Format(PyExc_RuntimeError, "Index out of range");
+        PyErr_Format(PyExc_RuntimeError, "%s", "Index out of range");
         return NULL;
     }
     try {
         c = self->alm(l,m);
         return PyComplex_FromDoubles((double)c.real(), (double)c.imag());
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return NULL;
     }
 }
@@ -161,7 +161,7 @@ static int AlmObject_set(AlmObject *self, PyObject *ind, PyObject *val) {
     xcomplex<double> c;
     if (!PyArg_ParseTuple(ind, "ii", &l, &m)) return -1;
     if (l < 0 || l > lmax || m < 0 || m > mmax || m > l) {
-        PyErr_Format(PyExc_RuntimeError, "Index out of range");
+        PyErr_Format(PyExc_RuntimeError, "%s", "Index out of range");
         return -1;
     }
     if (PyComplex_Check(val)) {
@@ -171,14 +171,14 @@ static int AlmObject_set(AlmObject *self, PyObject *ind, PyObject *val) {
     } else if (PyInt_Check(val)) {
         c.Set((double) PyInt_AsLong(val), 0);
     } else {
-        PyErr_Format(PyExc_ValueError, "Could not convert value to complex");
+        PyErr_Format(PyExc_ValueError, "%s", "Could not convert value to complex");
         return -1;
     }
     try {
         self->alm(l,m) = c;
         return 0;
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return -1;
     }
 }
@@ -211,7 +211,7 @@ static PyObject * AlmObject_to_map(AlmObject *self, PyObject *args) {
     if (strcmp(PyString_AsString(ordering), "NEST") == 0) {
         scheme = NEST;
     } else if (strcmp(PyString_AsString(ordering), "RING") != 0) {
-        PyErr_Format(PyExc_ValueError,"ordering must be 'RING' or 'NEST'.");
+        PyErr_Format(PyExc_ValueError, "%s", "ordering must be 'RING' or 'NEST'.");
         return NULL;
     }
     try {
@@ -224,7 +224,7 @@ static PyObject * AlmObject_to_map(AlmObject *self, PyObject *args) {
         for (int i=0; i < npix; i++) IND1(rv,i,double) = map[i];
         return PyArray_Return(rv);
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return NULL;
     }
 }
@@ -237,7 +237,7 @@ static PyObject * AlmObject_from_map(AlmObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "O!i", &PyArray_Type, &data, &iter))
         return NULL;
     if (RANK(data) != 1) {
-        PyErr_Format(PyExc_ValueError, "data must have 1 dimension.");
+        PyErr_Format(PyExc_ValueError, "%s", "data must have 1 dimension.");
         return NULL;
     }
     nside = hpb.npix2nside(DIM(data,0));
@@ -276,7 +276,7 @@ static PyObject * AlmObject_from_map(AlmObject *self, PyObject *args) {
         Py_INCREF(Py_None);
         return Py_None;
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return NULL;
     }
 }
@@ -331,7 +331,7 @@ static PyObject * AlmObject_set_data(AlmObject *self, PyObject *args) {
     xcomplex<double> c;
     if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &data)) return NULL;
     if (RANK(data) != 1 || DIM(data,0) != num_alms) {
-        PyErr_Format(PyExc_ValueError, "data must have length %d.", num_alms);
+        PyErr_Format(PyExc_ValueError, "%s", "data must have length %d.", num_alms);
         return NULL;
     }
     CHK_ARRAY_TYPE(data, NPY_CDOUBLE);

--- a/src/_healpix/healpix_wrap.cpp
+++ b/src/_healpix/healpix_wrap.cpp
@@ -102,7 +102,7 @@ static int HPBObject_init(HPBObject *self, PyObject *args, PyObject *kwds) {
         if (nside == -1) self->hpb = Healpix_Base();
         else self->hpb = Healpix_Base(nside, scheme, SET_NSIDE);
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return -1;
     }
     return 0;
@@ -122,7 +122,7 @@ static PyObject * HPBObject_npix2nside(HPBObject *self, PyObject *args) {
     try {
         return PyInt_FromLong(self->hpb.npix2nside(npix));
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return NULL;
     }
 }
@@ -151,7 +151,7 @@ static PyObject * HPBObject_nest_ring_conv(HPBObject *self, PyObject *args) {
             return NULL;
         }
     } catch (Message_error &e) {
-        PyErr_Format(PyExc_RuntimeError, e.what());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.what());
         return NULL;
     }
     Py_INCREF(px);

--- a/src/_miriad/miriad_wrap.cpp
+++ b/src/_miriad/miriad_wrap.cpp
@@ -49,7 +49,7 @@ static int UVObject_init(UVObject *self, PyObject *args, PyObject *kwds) {
     switch (corrmode[0]) {
         case 'r': case 'j': break;
         default:
-            PyErr_Format(PyExc_ValueError, "UV corrmode must be 'r' or 'j' (got '%c')", corrmode[0]);
+            PyErr_Format(PyExc_ValueError, "%s", "UV corrmode must be 'r' or 'j' (got '%c')", corrmode[0]);
             return -1;
     }
     // Setup an error handler so MIRIAD doesn't just exit
@@ -61,7 +61,7 @@ static int UVObject_init(UVObject *self, PyObject *args, PyObject *kwds) {
         uvset_c(self->tno,"corr",corrmode,0,0.,0.,0.);
     } catch (MiriadError &e) {
         self->tno = -1;
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return -1;
     }
     return 0;
@@ -105,7 +105,7 @@ PyObject * UVObject_read(UVObject *self, PyObject *args) {
             uvread_c(self->tno, preamble,
                 (float *)data->data, (int *)flags->data, n2read, &nread);
         } catch (MiriadError &e) {
-            PyErr_Format(PyExc_RuntimeError, e.get_message());
+            PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
             return NULL;
         }
         if (preamble[3] != self->curtime) {
@@ -145,7 +145,7 @@ PyObject * UVObject_write(UVObject *self, PyObject *args) {
         &PyArray_Type, &uvw, &t, &i, &j,
         &PyArray_Type, &data, &PyArray_Type, &flags)) return NULL;
     if (RANK(uvw) != 1 || DIM(uvw,0) != 3) {
-        PyErr_Format(PyExc_ValueError,
+        PyErr_Format(PyExc_ValueError, "%s", 
             "uvw must have shape (3,) %d", RANK(uvw));
         return NULL;
     } else if (RANK(data)!=1 || RANK(flags)!=1 || DIM(data,0)!=DIM(flags,0)) {
@@ -158,7 +158,7 @@ PyObject * UVObject_write(UVObject *self, PyObject *args) {
     // Check for both int,long, b/c label of 32b number is platform dependent
     if (TYPE(flags) != NPY_INT && \
             (sizeof(int) == sizeof(long) && TYPE(flags) != NPY_LONG)) {
-        PyErr_Format(PyExc_ValueError, "type(flags) != NPY_LONG or NPY_INT");
+        PyErr_Format(PyExc_ValueError, "%s", "type(flags) != NPY_LONG or NPY_INT");
         return NULL;
     }
     // Fill up the preamble
@@ -172,7 +172,7 @@ PyObject * UVObject_write(UVObject *self, PyObject *args) {
         uvwrite_c(self->tno, preamble,
             (float *)data->data, (int *)flags->data, DIM(data,0));
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
     Py_INCREF(Py_None);
@@ -186,7 +186,7 @@ PyObject * UVObject_copyvr(UVObject *self, PyObject *args) {
     try {
         uvcopyvr_c(uv->tno, self->tno);
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
     Py_INCREF(Py_None);
@@ -200,7 +200,7 @@ PyObject * UVObject_trackvr(UVObject *self, PyObject *args) {
     try {
         uvtrack_c(self->tno, name, sw);
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
     Py_INCREF(Py_None);
@@ -258,11 +258,11 @@ PyObject * UVObject_rdvr(UVObject *self, PyObject *args) {
                 uvgetvr_c(self->tno,H_CMPLX,name,(char *)rv->data,length);
                 return PyArray_Return(rv);
             default:
-                PyErr_Format(PyExc_ValueError,"unknown var type: %c",type[0]);
+                PyErr_Format(PyExc_ValueError, "%s", "unknown var type: %c",type[0]);
                 return NULL;
         }
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }
@@ -320,13 +320,13 @@ PyObject * UVObject_wrvr(UVObject *self, PyObject *args) {
                 }
                 break;
             default:
-                PyErr_Format(PyExc_ValueError,"unknown var type: %c",type[0]);
+                PyErr_Format(PyExc_ValueError, "%s", "unknown var type: %c",type[0]);
                 return NULL;
         }
         Py_INCREF(Py_None);
         return Py_None;
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }
@@ -344,7 +344,7 @@ PyObject * UVObject_select(UVObject *self, PyObject *args) {
         try {
             uvselect_c(self->tno, name, n1, n2, include);
         } catch (MiriadError &e) {
-            PyErr_Format(PyExc_RuntimeError, e.get_message());
+            PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
             return NULL;
         }
     }
@@ -362,7 +362,7 @@ PyObject * UVObject_haccess(UVObject *self, PyObject *args) {
         CHK_IO(iostat);
         return PyInt_FromLong(item_hdl);
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }
@@ -376,7 +376,7 @@ PyObject * WRAP_hdaccess(UVObject *self, PyObject *args) {
         Py_INCREF(Py_None);
         return Py_None;
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }
@@ -402,12 +402,12 @@ PyObject * WRAP_hwrite_init(PyObject *self, PyObject *args) {
             case 'd': INIT(dble_item,H_DBLE_SIZE); break;
             case 'c': INIT(cmplx_item,H_CMPLX_SIZE); break;
             default:
-                PyErr_Format(PyExc_ValueError, "unknown item type: %c",type[0]);
+                PyErr_Format(PyExc_ValueError, "%s", "unknown item type: %c",type[0]);
                 return NULL;
         }
         return PyInt_FromLong(offset);
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }
@@ -449,7 +449,7 @@ PyObject * WRAP_hread_init(PyObject *self, PyObject *args) {
         PyErr_Format(PyExc_RuntimeError, "unknown item type");
         return NULL;
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }
@@ -522,7 +522,7 @@ PyObject * WRAP_hwrite(PyObject *self, PyObject *args) {
         }
         return PyInt_FromLong(offset);
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }
@@ -574,7 +574,7 @@ PyObject * WRAP_hread(PyObject *self, PyObject *args) {
                 return NULL;
         }
     } catch (MiriadError &e) {
-        PyErr_Format(PyExc_RuntimeError, e.get_message());
+        PyErr_Format(PyExc_RuntimeError, "%s", e.get_message());
         return NULL;
     }
 }


### PR DESCRIPTION
Hi Aron,
              We were tring to install aipy in Ubuntu 16.04. It seems there were some security issues with compilation (https://stackoverflow.com/questions/17260409/fprintf-err-orformat-not-a-string-literal-and-no-format-arguments-werror-for/17260886#17260886) that were turning some of the warnings into error. We think we have fixed it now using this help by editing the PyErr_Format(PyExc_RuntimeError, e.what()); to PyErr_Format(PyExc_RuntimeError, "%s",  e.what()) in 3 files miriad_wrap.cpp, alm_wrap.cpp and healpix_wrap.cpp.

Regards,
 Abhik