### PR TITLE
Add stopt and duration to itemtable

### DIFF
--- a/aipy_src/miriad.py
+++ b/aipy_src/miriad.py
@@ -47,6 +47,8 @@ itemtable = {
     'bandpass': 'c',
     'nspect0' : 'i',
     'nchan0'  : 'i',
+    'stopt'   : 'd',
+    'duration': 'd',
 }
 
 data_types = {


### PR DESCRIPTION
This adds the values `stopt` and `duration` to the itemtable used to read miriad files. This allows for these values to be accessed in files that contain them.