### PR TITLE
aipy_src/_miriad/miriad_wrap.h: improve some ergonomics for Python 3

### DIFF
--- a/aipy_src/_miriad/miriad_wrap.h
+++ b/aipy_src/_miriad/miriad_wrap.h
@@ -48,11 +48,11 @@
         PyErr_Format(PyExc_ValueError, "expected a string"); \
         return NULL; }
 #define CHK_INT(o) \
-    if (!PyInt_Check(o)) { \
+    if (!PyInt_Check(o) && !PyIndex_Check(o)) { \
         PyErr_Format(PyExc_ValueError, "expected an int"); \
         return NULL; }
 #define CHK_LONG(o) \
-    if (!PyLong_Check(o)) { \
+    if (!PyLong_Check(o) && !PyIndex_Check(o)) { \
         PyErr_Format(PyExc_ValueError, "expected a long"); \
         return NULL; }
 #define CHK_FLOAT(o) \


### PR DESCRIPTION
In Python 3, the Numpy integer types such as np.int32 are no longer subclasses of the basic `int` type. Therefore writing out scalar integers in MIRIAD stopped working when those integers were Numpy-y. Adding `PyIndex_Check` enables this use case again.