### PR TITLE
Fix BeamAlm set_params

### DIFF
--- a/aipy_src/fit.py
+++ b/aipy_src/fit.py
@@ -288,7 +288,7 @@ class BeamAlm(amp.BeamAlm):
             changed = True
             data = np.array(prms[p])
             c = int(p[3:])
-            data.shape = (data.size/2, 2)
+            data.shape = (data.size//2, 2)
             data = data[:,0] + data[:,1] * 1j
             if c < len(self.alm): self.alm[-1-c].set_data(data)
         if changed: self.update()


### PR DESCRIPTION
Use truncation division which was intended and broken by making aipy both python 2 and 3 compatible.

This is currently breaking hera_cal: https://travis-ci.org/HERA-Team/hera_cal/builds/417473551?utm_source=github_status&utm_medium=notification