### PR TITLE
ci: fix stupid typo in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,15 +25,7 @@ jobs:
           python -m build .
 
       - name: Publish to PyPI
-        if: startsWith(github.event.ref, 'refs/tags/v') &&  
+        if: startsWith(github.event.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}
-
-      - name: Publish the release notes
-        uses: release-drafter/release-drafter@v5.21.1
-        with:
-          publish: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
-          tag: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes a stupid typo in the workflow, and removes the release-drafter step since that runs on every push.