### PR TITLE
ci: see if the version is correct...

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Python distributions to PyPI
 
 on:
   release:
-    types: [published, created]
+    types: [published, created, edited]
 
 jobs:
   build-n-publish:
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m build .
           ls dist/
-          
+
       - name: Publish to PyPI
         if: startsWith(github.event.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Python distributions to PyPI
 
 on:
   release:
-    types: [published, created, edited]
+    types: [published]
 
 jobs:
   build-n-publish:
@@ -26,7 +26,6 @@ jobs:
           ls dist/
 
       - name: Publish to PyPI
-        if: startsWith(github.event.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Python distributions to PyPI
 
 on:
   release:
-    types: [published]
+    types: [published, created]
 
 jobs:
   build-n-publish:
@@ -23,7 +23,8 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build .
-
+          ls dist/
+          
       - name: Publish to PyPI
         if: startsWith(github.event.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
This removes the condition that the ref starts with a tag for doing a release. I thought this condition should always pass, but I might be getting something wrong. I'm hoping this works, but we'll only know once we merge and make a release :/